### PR TITLE
Conditions renamed

### DIFF
--- a/real/processors/Intel-8051/Intel_8051_25.cpog
+++ b/real/processors/Intel-8051/Intel_8051_25.cpog
@@ -249,6 +249,6 @@ ALU MAU
 ALU_2 COND
 COND IFU
 ALU_2 PCIU_2
-:!x_5 PCIU_2
-:x_5 COND
+:!cd PCIU_2
+:cd COND
 .end

--- a/real/processors/Intel-8051/Intel_8051_30.cpog
+++ b/real/processors/Intel-8051/Intel_8051_30.cpog
@@ -13,8 +13,8 @@ PCIU_2 IFU_2
 PCIU ALU
 IFU ALU_2
 ALU PCIU_2
-:!x_5 IFU
-:x_5 PCIU_2
+:!cd IFU
+:cd PCIU_2
 .end
 
 .scenario CPOG_2
@@ -24,8 +24,8 @@ ALU IFU
 ALU PCIU_2
 IFU ALU_2
 PCIU_2 IFU_2
-:x_5 IFU
-:!x_5 PCIU_2
+:cd IFU
+:!cd PCIU_2
 .end
 
 .scenario CPOG_3
@@ -39,8 +39,8 @@ ALU MAU
 PCIU_2 IFU_2
 ALU_2 COND
 COND IFU
-:x_5 PCIU_2
-:!x_5 COND
+:cd PCIU_2
+:!cd COND
 .end
 
 .scenario CPOG_4
@@ -56,9 +56,9 @@ IFU_2 ALU_3
 PCIU_3 IFU_3
 IFU ALU
 ALU_2 MAU_2
-:x_5 PCIU_3
-:!x_5 IFU_2
-:!x_5 PCIU_2
+:cd PCIU_3
+:!cd IFU_2
+:!cd PCIU_2
 .end
 
 .scenario CPOG_5
@@ -304,8 +304,8 @@ ALU MAU
 ALU_2 COND
 COND IFU
 ALU_2 PCIU_2
-:!x_5 PCIU_2
-:x_5 COND
+:!cd PCIU_2
+:cd COND
 .end
 
 .scenario CPOG_29
@@ -318,6 +318,6 @@ ALU_3 IFU_2
 IFU ALU_3
 ALU_2 COND
 COND IFU
-:x_5 PCIU_2
-:!x_5 COND
+:cd PCIU_2
+:!cd COND
 .end

--- a/real/processors/Intel-8051/Intel_8051_35.cpog
+++ b/real/processors/Intel-8051/Intel_8051_35.cpog
@@ -13,8 +13,8 @@ PCIU_2 IFU_2
 PCIU ALU
 IFU ALU_2
 ALU PCIU_2
-:!x_6 IFU
-:x_6 PCIU_2
+:!cd IFU
+:cd PCIU_2
 .end
 
 .scenario CPOG_2
@@ -24,8 +24,8 @@ ALU IFU
 ALU PCIU_2
 IFU ALU_2
 PCIU_2 IFU_2
-:x_6 IFU
-:!x_6 PCIU_2
+:cd IFU
+:!cd PCIU_2
 .end
 
 .scenario CPOG_3
@@ -39,8 +39,8 @@ ALU MAU
 PCIU_2 IFU_2
 ALU_2 COND
 COND IFU
-:x_6 PCIU_2
-:!x_6 COND
+:cd PCIU_2
+:!cd COND
 .end
 
 .scenario CPOG_4
@@ -56,9 +56,9 @@ IFU_2 ALU_3
 PCIU_3 IFU_3
 IFU ALU
 ALU_2 MAU_2
-:x_6 PCIU_3
-:!x_6 IFU_2
-:!x_6 PCIU_2
+:cd PCIU_3
+:!cd IFU_2
+:!cd PCIU_2
 .end
 
 .scenario CPOG_5
@@ -77,9 +77,9 @@ ALU_3 COND_2
 COND_2 IFU_2
 COND ALU_2
 IFU COND
-:x_6 PCIU_3
-:!x_6 COND
-:!x_6 COND_2
+:cd PCIU_3
+:!cd COND
+:!cd COND_2
 .end
 
 .scenario CPOG_6
@@ -94,9 +94,9 @@ IFU PCIU_2
 ALU_3 IFU_3
 ALU_2 IFU_2
 IFU_2 ALU_3
-:!x_6 PCIU_2
-:!x_6 IFU_2
-:x_6 PCIU_3
+:!cd PCIU_2
+:!cd IFU_2
+:cd PCIU_3
 .end
 
 .scenario CPOG_7
@@ -112,9 +112,9 @@ ALU_2 PCIU_3
 IFU PCIU_2
 PCIU_3 IFU_3
 ALU_3 IFU_3
-:x_6 PCIU_3
-:!x_6 IFU_2
-:!x_6 PCIU_2
+:cd PCIU_3
+:!cd IFU_2
+:!cd PCIU_2
 .end
 
 .scenario CPOG_8
@@ -130,9 +130,9 @@ ALU_2 IFU_2
 PCIU IFU
 ALU_3 IFU_3
 ALU_3 MAU_2
-:!x_6 IFU_2
-:x_6 PCIU_3
-:!x_6 PCIU_2
+:!cd IFU_2
+:cd PCIU_3
+:!cd PCIU_2
 .end
 
 .scenario CPOG_9
@@ -148,9 +148,9 @@ MAU ALU_2
 ALU MAU
 IFU PCIU_2
 ALU_2 PCIU_3
-:!x_6 PCIU_3
-:x_6 IFU_2
-:x_6 PCIU_2
+:!cd PCIU_3
+:cd IFU_2
+:cd PCIU_2
 .end
 
 .scenario CPOG_10
@@ -396,8 +396,8 @@ ALU MAU
 ALU_2 COND
 COND IFU
 ALU_2 PCIU_2
-:!x_6 PCIU_2
-:x_6 COND
+:!cd PCIU_2
+:cd COND
 .end
 
 .scenario CPOG_34
@@ -410,6 +410,6 @@ ALU_3 IFU_2
 IFU ALU_3
 ALU_2 COND
 COND IFU
-:x_6 PCIU_2
-:!x_6 COND
+:cd PCIU_2
+:!cd COND
 .end

--- a/real/processors/Intel-8051/Intel_8051_37.cpog
+++ b/real/processors/Intel-8051/Intel_8051_37.cpog
@@ -13,8 +13,8 @@ PCIU_2 IFU_2
 PCIU ALU
 IFU ALU_2
 ALU PCIU_2
-:!x_6 IFU
-:x_6 PCIU_2
+:!cd IFU
+:cd PCIU_2
 .end
 
 .scenario CPOG_2
@@ -24,8 +24,8 @@ ALU IFU
 ALU PCIU_2
 IFU ALU_2
 PCIU_2 IFU_2
-:x_6 IFU
-:!x_6 PCIU_2
+:cd IFU
+:!cd PCIU_2
 .end
 
 .scenario CPOG_3
@@ -39,8 +39,8 @@ ALU MAU
 PCIU_2 IFU_2
 ALU_2 COND
 COND IFU
-:x_6 PCIU_2
-:!x_6 COND
+:cd PCIU_2
+:!cd COND
 .end
 
 .scenario CPOG_4
@@ -56,9 +56,9 @@ IFU_2 ALU_3
 PCIU_3 IFU_3
 IFU ALU
 ALU_2 MAU_2
-:x_6 PCIU_3
-:!x_6 IFU_2
-:!x_6 PCIU_2
+:cd PCIU_3
+:!cd IFU_2
+:!cd PCIU_2
 .end
 
 .scenario CPOG_5
@@ -77,9 +77,9 @@ ALU_3 COND_2
 COND_2 IFU_2
 COND ALU_2
 IFU COND
-:x_6 PCIU_3
-:!x_6 COND
-:!x_6 COND_2
+:cd PCIU_3
+:!cd COND
+:!cd COND_2
 .end
 
 .scenario CPOG_6
@@ -94,9 +94,9 @@ IFU PCIU_2
 ALU_3 IFU_3
 ALU_2 IFU_2
 IFU_2 ALU_3
-:!x_6 PCIU_2
-:!x_6 IFU_2
-:x_6 PCIU_3
+:!cd PCIU_2
+:!cd IFU_2
+:cd PCIU_3
 .end
 
 .scenario CPOG_7
@@ -112,9 +112,9 @@ ALU_2 PCIU_3
 IFU PCIU_2
 PCIU_3 IFU_3
 ALU_3 IFU_3
-:x_6 PCIU_3
-:!x_6 IFU_2
-:!x_6 PCIU_2
+:cd PCIU_3
+:!cd IFU_2
+:!cd PCIU_2
 .end
 
 .scenario CPOG_8
@@ -130,9 +130,9 @@ ALU_2 IFU_2
 PCIU IFU
 ALU_3 IFU_3
 ALU_3 MAU_2
-:!x_6 IFU_2
-:x_6 PCIU_3
-:!x_6 PCIU_2
+:!cd IFU_2
+:cd PCIU_3
+:!cd PCIU_2
 .end
 
 .scenario CPOG_9
@@ -148,9 +148,9 @@ MAU ALU_2
 ALU MAU
 IFU PCIU_2
 ALU_2 PCIU_3
-:!x_6 PCIU_3
-:x_6 IFU_2
-:x_6 PCIU_2
+:!cd PCIU_3
+:cd IFU_2
+:cd PCIU_2
 .end
 
 .scenario CPOG_10
@@ -418,8 +418,8 @@ ALU MAU
 ALU_2 COND
 COND IFU
 ALU_2 PCIU_2
-:!x_6 PCIU_2
-:x_6 COND
+:!cd PCIU_2
+:cd COND
 .end
 
 .scenario CPOG_36
@@ -432,6 +432,6 @@ ALU_3 IFU_2
 IFU ALU_3
 ALU_2 COND
 COND IFU
-:x_6 PCIU_2
-:!x_6 COND
+:cd PCIU_2
+:!cd COND
 .end

--- a/real/processors/TI-MSP430/TI_MSP_430_4.cpog
+++ b/real/processors/TI-MSP430/TI_MSP_430_4.cpog
@@ -20,12 +20,12 @@ ALU IFU
 IFU ALU2
 ALU PCIU2
 ALU2 IFU2
-:!x_3 IFU
-:!x_3 ALU2
+:!cd IFU
+:!cd ALU2
 .end
 
 .scenario CPOG_3
 PCIU IFU
 ALU ALU2
-:!x_3 ALU2
+:!cd ALU2
 .end

--- a/real/processors/TI-MSP430/TI_MSP_430_5.cpog
+++ b/real/processors/TI-MSP430/TI_MSP_430_5.cpog
@@ -24,12 +24,12 @@ ALU IFU
 IFU ALU2
 ALU PCIU2
 ALU2 IFU2
-:!x_3 IFU
-:!x_3 ALU2
+:!cd IFU
+:!cd ALU2
 .end
 
 .scenario CPOG_4
 PCIU IFU
 ALU ALU2
-:!x_3 ALU2
+:!cd ALU2
 .end

--- a/real/processors/TI-MSP430/TI_MSP_430_6.cpog
+++ b/real/processors/TI-MSP430/TI_MSP_430_6.cpog
@@ -24,7 +24,7 @@ ALU IFU2
 .scenario CPOG_4
 PCIU IFU
 ALU ALU2
-:!x_3 ALU2
+:!cd ALU2
 .end
 
 .scenario CPOG_5
@@ -36,6 +36,6 @@ ALU IFU
 IFU ALU2
 ALU PCIU2
 ALU2 IFU2
-:!x_3 IFU
-:!x_3 ALU2
+:!cd IFU
+:!cd ALU2
 .end

--- a/real/processors/TI-MSP430/TI_MSP_430_7.cpog
+++ b/real/processors/TI-MSP430/TI_MSP_430_7.cpog
@@ -30,14 +30,14 @@ ALU IFU
 IFU ALU2
 ALU PCIU2
 ALU2 IFU2
-:x_3 IFU
-:x_3 ALU2
+:cd IFU
+:cd ALU2
 .end
 
 .scenario CPOG_5
 PCIU IFU
 ALU ALU2
-:x_3 ALU2
+:cd ALU2
 .end
 
 .scenario CPOG_6

--- a/real/processors/TI-MSP430/TI_MSP_430_8.cpog
+++ b/real/processors/TI-MSP430/TI_MSP_430_8.cpog
@@ -29,9 +29,9 @@ ALU IFU
 IFU ALU2
 ALU2 IFU2
 ALU PCIU2
-:x_3 ALU2
-:!x_3 PCIU2
-:x_3 IFU
+:cd ALU2
+:!cd PCIU2
+:cd IFU
 .end
 
 .scenario CPOG_5
@@ -43,14 +43,14 @@ ALU IFU
 IFU ALU2
 ALU PCIU2
 ALU2 IFU2
-:x_3 IFU
-:x_3 ALU2
+:cd IFU
+:cd ALU2
 .end
 
 .scenario CPOG_6
 PCIU IFU
 ALU ALU2
-:x_3 ALU2
+:cd ALU2
 .end
 
 .scenario CPOG_7


### PR DESCRIPTION
Renamed conditions in CPOG files. This is needed for the Single literal encoding which uses more variables for the encoding, overlapping the ones with the same names.
